### PR TITLE
IPv6 localhost fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ class Foo
   end
 end
 
-EM.run { Foo.new 10, 20 } 
+EM.run { Foo.new 10, 20 }
 ```
 
 Running it will print out a message telling you Pry is waiting for a
 program to connect itself to it:
 
-     [pry-remote-em] listening for connections on pryem://localhost:6462/
+     [pry-remote-em] listening for connections on pryem://127.0.0.1:6462/
 
 You can then connect to the pry session using ``pry-remote-em``:
 
@@ -114,12 +114,12 @@ EM.run {
 $ pry-remote-em pryem://127.0.0.1:6462/
 [pry-remote-em] client connected to pryem://127.0.0.1:6462/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry("pretty_print")> 
+[1] pry("pretty_print")>
 
 $ pry-remote-em  pryem://127.0.0.1:6463/
 [pry-remote-em] client connected to pryem://127.0.0.1:6463/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry("pack")> 
+[1] pry("pack")>
 
 $ pry-remote-em  pryem://127.0.0.1:6464/
 [pry-remote-em] client connected to pryem://127.0.0.1:6464/
@@ -129,12 +129,12 @@ $ pry-remote-em  pryem://127.0.0.1:6464/
 $ pry-remote-em  pryem://127.0.0.1:6465/
 [pry-remote-em] client connected to pryem://127.0.0.1:6465/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry("to_json")> 
+[1] pry("to_json")>
 
 $ pry-remote-em  pryem://127.0.0.1:6466/
 [pry-remote-em] client connected to pryem://127.0.0.1:6466/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryem
-[1] pry(#<RubyVM::InstructionSequence>)> 
+[1] pry(#<RubyVM::InstructionSequence>)>
 ```
 
 ## Server Broker
@@ -142,9 +142,9 @@ $ pry-remote-em  pryem://127.0.0.1:6466/
 When more than one server is running on a given host and each server is
 started with :auto it can be time consuming to manually figure out which
 port each server is running on. The Broker which listens on port 6461
-keeps track of which server is running on which port. 
+keeps track of which server is running on which port.
 
-By default the pry-remote-em cli utility will connect to the broker and 
+By default the pry-remote-em cli utility will connect to the broker and
 retrieve a list of known servers. You can then select one to connect to
 by its id, name or url. You can also choose to proxy your connection
 through the broker to the selected server.
@@ -182,7 +182,7 @@ variable, or in :broker_host option passed to #remote_pry_em.
 
 ```shell
 
-$ PRYEMBROKER=0.0.0.0 be ./test/service.rb  
+$ PRYEMBROKER=0.0.0.0 be ./test/service.rb
 I, [2012-07-13T21:10:00.936993 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:6462/
 I, [2012-07-13T21:10:00.937132 #88528]  INFO -- : [pry-remote-em broker] listening on pryem://0.0.0.0:6461
 I, [2012-07-13T21:10:00.937264 #88528]  INFO -- : [pry-remote-em] listening for connections on pryem://0.0.0.0:1337/
@@ -196,13 +196,13 @@ I, [2012-07-13T21:10:00.939640 #88528]  INFO -- : [pry-remote-em] listening for 
 I, [2012-07-13T21:10:01.031576 #88528]  INFO -- : [pry-remote-em broker] received client connection from 127.0.0.1:62288
 I, [2012-07-13T21:10:01.031931 #88528]  INFO -- : [pry-remote-em] client connected to pryem://127.0.0.1:6461/
 I, [2012-07-13T21:10:01.032120 #88528]  INFO -- : [pry-remote-em] remote is PryRemoteEm 0.7.0 pryem
-I, [2012-07-13T21:10:01.032890 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6462/ - "#<#<Class:0x007f924b9bbee8>>" 
-I, [2012-07-13T21:10:01.125123 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6469/ - "#<#<Class:0x007f924b9bbee8>>" 
+I, [2012-07-13T21:10:01.032890 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6462/ - "#<#<Class:0x007f924b9bbee8>>"
+I, [2012-07-13T21:10:01.125123 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6469/ - "#<#<Class:0x007f924b9bbee8>>"
 I, [2012-07-13T21:10:01.125487 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6467/ - "#<#<Class:0x007f924b9bbee8>>"
 I, [2012-07-13T21:10:01.490729 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6464/ - "#<#<Class:0x007f924b9bbee8>>"
-I, [2012-07-13T21:10:01.583015 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:1337/ - "#<Foo>"                       
+I, [2012-07-13T21:10:01.583015 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:1337/ - "#<Foo>"
 I, [2012-07-13T21:10:01.674842 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6466/ - "#<#<Class:0x007f924b9bbee8>>"
-I, [2012-07-13T21:10:01.766813 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6468/ - "#<#<Class:0x007f924b9bbee8>>" 
+I, [2012-07-13T21:10:01.766813 #88528]  INFO -- : [pry-remote-em broker] registered pryem://127.0.0.1:6468/ - "#<#<Class:0x007f924b9bbee8>>"
 I, [2012-07-13T21:10:01.858423 #88528]  INFO -- : [pry-remote-em broker] registered pryems://127.0.0.1:6465/ - "#<#<Class:0x007f924b9bbee8>>"
 ```
 
@@ -220,18 +220,18 @@ TLS enabled server.
 
 
 ## TLS Encryption
-  
-When creating a server pass the :tls => true option to enable TLS. 
+
+When creating a server pass the :tls => true option to enable TLS.
 
 ```ruby
 obj.remote_pry_em('localhost', :auto, :tls => true)
 ```
 
-If you pass a Hash it will be used to configure the internal TLS handler. 
+If you pass a Hash it will be used to configure the internal TLS handler.
 
 ```ruby
 obj.remote_pry_em('localhost', :auto, :tls => {:private_key_file => '/tmp/server.key'})
-``` 
+```
 See [EventMachine::Connection#start_tls](http://eventmachine.rubyforge.org/EventMachine/Connection.html#M000296) for the available options.
 
 
@@ -244,7 +244,7 @@ $ pry-remote-em pryem://localhost:6462/
 [pry-remote-em] remote is PryRemoteEm 0.4.0 pryems
 [pry-remote-em] negotiating TLS
 [pry-remote-em] TLS connection established
-[1] pry(#<Hash>)> 
+[1] pry(#<Hash>)>
 ```
 
 To always require a TLS connection give pry-remote-em a pryem*s* URL. If
@@ -323,7 +323,7 @@ $ pry-remote-em pryems://localhost:6464/
 [pry-remote-em] TLS connection established
 user: caleb
 caleb's password: *****
-[1] pry(#<Hash>)> 
+[1] pry(#<Hash>)>
 ```
 
 
@@ -357,7 +357,7 @@ $ bin/pry-remote-em pryems:///
 [pry-remote-em] client connected to pryem://127.0.0.1:6462/
 [pry-remote-em] remote is PryRemoteEm 0.2.0 pryems
 [1] pry(#<Hash>)> key (^TAB ^TAB)
-key   key?  keys  
+key   key?  keys
 [1] pry(#<Hash>)> keys
 => [:encoding]
 ```
@@ -469,7 +469,7 @@ Copyright (c) 2012 Caleb Crane
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation 
+to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
 and/or sell copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following conditions:

--- a/bin/pry-remote-em
+++ b/bin/pry-remote-em
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+﻿#!/usr/bin/env ruby
 
 require 'uri'
 require 'highline'
@@ -9,24 +9,24 @@ options = {}
 OptionParser.new do |opts|
   opts.on("-c", "--connect NAME", "connect to the first pry remote em server matching NAME") do |name|
     options[:connect] = name
-  end 
+  end
   opts.on("-p", "--proxy NAME", "proxy through the broker to the first pry remote em server matching NAME") do |name|
     options[:proxy] = name
-  end 
+  end
 
   opts.on("--fh HOST", "--filter-host HOST", "only show servers listening at the given address (regexp)") do |host|
     if host =~ /^pryems?:\/\//
       ARGV.push(host)
-    else  
+    else
       options[:filter_host] = Regexp.new(host)
-    end 
-  end 
+    end
+  end
   opts.on("--fn NAME", "--filter-name NAME", "only show servers with a matching name (regexp)") do |name|
     if name =~ /^pryems?:\/\//
       ARGV.push(name)
-    else  
+    else
       options[:filter_name] = Regexp.new(name)
-    end 
+    end
   end
   opts.on("--[no-]fs", "--[no-]filter-ssl", "show only servers that support ssl") do |ssl|
     options[:filter_ssl] = ssl
@@ -38,12 +38,12 @@ OptionParser.new do |opts|
   opts.on('--ss', '--sort-ssl', 'sort by ssl support') { options[:sort] = :ssl }
 
   opts.parse!(ARGV)
-end 
+end
 
-uri = ARGV[0] || "pryem://localhost:#{PryRemoteEm::DEF_BROKERPORT}"
+uri = ARGV[0] || "pryem://#{PryRemoteEm::DEF_BROKERHOST}:#{PryRemoteEm::DEF_BROKERPORT}"
 uri = URI.parse(uri)
 unless %w(pryem pryems).include?(uri.scheme)
-  abort "only pryem URIs are currently supported\n usage: pryem[s]://127.0.0.1:#{PryRemoteEm::DEF_BROKERPORT}" 
+  abort "only pryem URIs are currently supported\n usage: pryem[s]://#{PryRemoteEm::DEF_BROKERHOST}:#{PryRemoteEm::DEF_BROKERPORT}"
 end
 uri.port = PryRemoteEm::DEF_BROKERPORT unless uri.port
 
@@ -57,7 +57,7 @@ auth_proc = proc do
              HighLine.new.ask("#{user}'s password: ") { |q| q.echo = '*'}
            else
              raise "password is required to authenticate"
-           end 
+           end
   [user, pass]
 end
 

--- a/lib/pry-remote-em.rb
+++ b/lib/pry-remote-em.rb
@@ -1,4 +1,4 @@
-begin
+﻿begin
   require 'openssl'
 rescue LoadError
   warn "OpenSSL support is not available"
@@ -11,10 +11,10 @@ require 'fiber'
 require 'uri'
 
 module PryRemoteEm
-  DEFHOST         = 'localhost'
+  DEFHOST         = '127.0.0.1'
   DEFPORT         = 6463
   DEF_BROKERPORT  = DEFPORT - 1
-  DEF_BROKERHOST  = 'localhost'
+  DEF_BROKERHOST  = '127.0.0.1'
   NEGOTIMER       = 15
 end
 

--- a/lib/pry-remote-em/broker.rb
+++ b/lib/pry-remote-em/broker.rb
@@ -1,4 +1,4 @@
-require 'socket'
+﻿require 'socket'
 require 'pry-remote-em'
 require 'pry-remote-em/client/broker'
 require 'pry-remote-em/client/proxy'
@@ -134,8 +134,8 @@ module PryRemoteEm
     end
 
     def receive_register_server(url, name)
-      url      = URI.parse(url)
-      url.host = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1'].include?(url.host)
+      url = URI.parse(url)
+      url.hostname = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1', '::1'].include?(url.hostname)
       log.info("[pry-remote-em broker] registered #{url} - #{name.inspect}") unless Broker.servers[url] == name
       Broker.servers[url] = name
       Broker.hbeats[url]  = Time.new
@@ -144,8 +144,8 @@ module PryRemoteEm
     end
 
     def receive_unregister_server(url)
-      url      = URI.parse(url)
-      url.host = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1'].include?(url.host)
+      url = URI.parse(url)
+      url.hostname = peer_ip if ['0.0.0.0', 'localhost', '127.0.0.1', '::1'].include?(url.hostname)
       log.warn("[pry-remote-em broker] unregister #{url}")
       Broker.servers.delete(url)
     end
@@ -181,6 +181,7 @@ module PryRemoteEm
       return @peer_ip if @peer_ip
       return "" if get_peername.nil?
       @peer_port, @peer_ip = Socket.unpack_sockaddr_in(get_peername)
+      @peer_ip = '127.0.0.1' if @peer_ip == '::1' # Little hack to avoid segmentation fault in EventMachine 1.2.0.1 while connecting to PryRemoteEm Server from localhost with IPv6 address
       @peer_ip
     end
 


### PR DESCRIPTION
While connecting to PryRemoteEm Server from localhost with IPv6 address on EventMachine 1.2.0.1 there is segmentation fault problem and few other bugs, so only this hack with 127.0.0.1 instead of localhost everywhere can help (no ideas why).
Also use hostname instead of host on URI for IPv6 localhost "::1" support, see:
https://bugs.ruby-lang.org/issues/3788